### PR TITLE
imomochi06 レストラン一覧ページにページャ実装（フロント側）

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "axios": "^0.16.1",
+    "querystringify": "^1.0.0",
     "vue": "^2.2.6",
     "vue-cookies": "^1.2.0",
     "vue-router": "^2.3.1",

--- a/app/src/components/Root.vue
+++ b/app/src/components/Root.vue
@@ -2,8 +2,13 @@
   <div class="root">
     <h1>レストラン一覧</h1>
       <button v-on:click="greet">Greet</button>
-      <button v-on:click="genNextPageLink">g</button>
-      
+      <div class="pager">
+        <h3>
+          <a v-if="page * 1 > 1" v-vind:href=previousPageLink>{{ page * 1 - 1 }}</a>
+          {{ page }}
+          <a v-bind:href=nextPageLink>{{ page * 1 + 1 }}</a>
+        </h3>
+      </div>    
       <ul>
         <li v-for="restaurant in restaurants">
           <div>
@@ -30,14 +35,28 @@
 <script>
 const vuecookie = require('vue-cookies')
 const axios = require('axios')
+const qs = require('querystringify')
+const query = qs.parse(window.location.search)
+const page = Number(query['page']) || 1
+
 export default {
   name: 'root',
   data () {
     return {
+      page: page,
+      nextPageLink: '/restaurants' + qs.stringify({ page: page + 1 }, true),
+      previousPageLink: '/restaurants' + qs.stringify({ page: page - 1 }, true),
       restaurants: axios
-          .get('/api/restaurants')
+          .get('/api/restaurants', {
+            params: {
+              page: page
+            }
+          })
           .then(res => {
             this.$data.restaurants = res.data
+          })
+          .catch(function (error) {
+            console.log(error)
           }),
       cookie: {
         id: vuecookie.get('id'),
@@ -48,16 +67,6 @@ export default {
   methods: {
     greet: function (event) {
       alert('Hello')
-    },
-    genNextPageLink: function () {
-      console.log(this)
-      alert(this)
-    },
-    getCurrentPage: function () {
-      alert()
-    },
-    genPreviousPageLink: function () {
-      alert()
     }
   }
 }

--- a/app/src/components/Root.vue
+++ b/app/src/components/Root.vue
@@ -4,7 +4,7 @@
       <button v-on:click="greet">Greet</button>
       <div class="pager">
         <h3>
-          <a v-if="page * 1 > 1" v-vind:href=previousPageLink>{{ page * 1 - 1 }}</a>
+          <a v-if="page * 1 > 1" v-bind:href=previousPageLink>{{ page * 1 - 1 }}</a>
           {{ page }}
           <a v-bind:href=nextPageLink>{{ page * 1 + 1 }}</a>
         </h3>


### PR DESCRIPTION
すでにサーバサイド側でページャメソッドの実装は完了している。
- [x] /restaurants?page=2の形式でアクセスして一覧表示する
- [x] 前のページ/次のページに移動できる

フロント側でquery文字列つきのリンクを発行する（前後のページへの）